### PR TITLE
Change cursor to a themed system cursor instead of an unthemed browser cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
-# Imagus mod(hkpd's edition)
+# Imagus mod(my edition)
 
-Forked from [TheFantasticWarrior](https://github.com/TheFantasticWarrior/chrome-extension-imagus/)
-
-The only thing I have changed is the cursor when you hover over an image because the default one was ugly.
-
-The rest of this text comes from TheFantasticWarrior's readme
+forked(copied and modified) from community edition(their explanation down below, things are outdated though idk how much is still true)
 
 ## Install Instructions
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# Imagus mod(my edition)
+# Imagus mod(hkpd's edition)
 
-forked(copied and modified) from community edition(their explanation down below, things are outdated though idk how much is still true)
+Forked from [TheFantasticWarrior](https://github.com/TheFantasticWarrior/chrome-extension-imagus/)
+
+The only thing I have changed is the cursor when you hover over an image because the default one was ugly.
+
+The rest of this text comes from TheFantasticWarrior's readme
 
 ## Install Instructions
 

--- a/src/includes/app.js
+++ b/src/includes/app.js
@@ -43,8 +43,8 @@ if (document instanceof window.HTMLDocument) {
                 ("webkitTransform" in _ ? "-webkit-" : "") + "transform",
             "zoom-in":
                 (this.chrome && !this.browser) || this.mx || this.safari
-                    ? "-webkit-zoom-in"
-                    : "zoom-in",
+                    ? "-webkit-help"
+                    : "help",
         };
         _ = null;
     }


### PR DESCRIPTION
If you have the option to change the cursor when hovering over images enabled, then this changes the cursor to a cursor that is themed by the system instead of the default browser cursor that is very ugly and out of place if you have a custom cursor theme applied. 